### PR TITLE
docs: add contributing guide, issue templates, and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Report a bug in viewmd
+title: "bug: "
+labels: bug
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1. Open viewmd
+2. ...
+3. ...
+
+## Expected Behaviour
+
+What you expected to happen.
+
+## Actual Behaviour
+
+What actually happened.
+
+## Environment
+
+- **OS:** macOS / Windows / Linux (version)
+- **viewmd version:** (from title bar or package.json)
+- **Display:** Retina / non-Retina
+
+## Screenshots
+
+If applicable, add screenshots.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest a new feature for viewmd
+title: "feat: "
+labels: enhancement
+---
+
+## Description
+
+A clear description of the feature you'd like.
+
+## Motivation
+
+What problem does this solve? What's your use case?
+
+## Proposed Solution
+
+How do you think this could work? (optional)
+
+## Alternatives Considered
+
+Any workarounds or alternatives you've tried.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Changes
+
+<!-- Bullet points of what changed -->
+
+-
+
+## Test Plan
+
+<!-- How can reviewers verify? What tests were added? -->
+
+- [ ] `npm test` passes
+- [ ] `npm run build && npm run test:e2e` passes
+- [ ] Visual check on macOS
+
+## Screenshots
+
+<!-- For UI changes, before/after screenshots -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,136 @@
+# Contributing to viewmd
+
+Thanks for your interest in contributing! This guide covers how to report bugs, suggest features, and submit code changes.
+
+## Reporting Issues
+
+Open an issue at [github.com/globalroo/markdown-viewer/issues](https://github.com/globalroo/markdown-viewer/issues).
+
+### Bug Reports
+
+Please include:
+
+- **What happened** — describe the problem clearly
+- **Steps to reproduce** — numbered steps to trigger the bug
+- **Expected behaviour** — what you expected to happen instead
+- **Environment** — OS, viewmd version (shown in the title bar or `package.json`), screen type (Retina/non-Retina)
+- **Screenshots** — if it's a visual issue, a screenshot helps enormously
+
+### Feature Requests
+
+Please include:
+
+- **What you'd like** — describe the feature
+- **Why** — what problem does it solve? What's your use case?
+- **Alternatives considered** — have you tried workarounds?
+
+We use Gestalt multi-agent review for feature planning, so well-described requests help us ideate effectively.
+
+## Submitting Changes
+
+### Setup
+
+```bash
+git clone https://github.com/globalroo/markdown-viewer.git
+cd markdown-viewer
+npm install
+```
+
+### Development
+
+```bash
+npm run dev           # Start Vite dev server
+npx electron .        # In another terminal (NODE_ENV=development)
+```
+
+### Testing
+
+```bash
+npm test              # Run unit tests (Vitest)
+npm run build && npm run test:e2e   # Run E2E tests (Playwright + Electron)
+```
+
+All tests must pass before submitting a PR. We currently have 140+ tests across unit and E2E.
+
+### Pull Request Process
+
+1. **Create a feature branch** from `main`:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **Make your changes.** Follow existing code patterns:
+   - TypeScript strict mode
+   - Zustand for state management
+   - CSS custom properties for theming
+   - IPC handlers validate all paths via `isPathAllowed()`
+
+3. **Write tests.** New features need:
+   - **Unit tests** in `tests/unit/` for store logic, validation, pure functions
+   - **E2E tests** in `tests/e2e/` for user-facing behaviour (Playwright + Electron)
+
+4. **Run the full test suite:**
+   ```bash
+   npm test && npm run build && npm run test:e2e
+   ```
+
+5. **Build and verify locally:**
+   ```bash
+   npm run build
+   npx electron .
+   ```
+
+6. **Submit your PR** against `main`:
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+   Then open a PR on GitHub.
+
+### PR Description
+
+Please include:
+
+- **Summary** — what does this PR do and why?
+- **Changes** — bullet points of what changed
+- **Test plan** — how can reviewers verify the changes? What tests were added?
+- **Screenshots** — for UI changes, before/after screenshots
+
+### What We Look For
+
+- **Security** — all file operations go through IPC with path validation. New IPC handlers must call `isPathAllowed()`. Mutating handlers must validate file extensions.
+- **Performance** — avoid paint-heavy CSS properties (no `backdrop-filter` in scroll containers). Use `contain`, `will-change`, and compositor-friendly transforms where appropriate. Test on Intel Mac if possible.
+- **Accessibility** — ARIA labels, keyboard navigation, WCAG AA contrast ratios on all themes.
+- **Bundle size** — prefer lightweight solutions. The app currently uses no heavy editor libraries (CodeMirror, Monaco) by design.
+
+## Code Style
+
+- No linter configured yet — follow existing patterns
+- Prefer `const` over `let`
+- Use `useCallback` and `useMemo` for React performance
+- CSS custom properties (`var(--name)`) for all theme-dependent values
+- `em`/`rem` for scalable sizes, `px` for fixed UI elements
+
+## Architecture
+
+```
+src/
+  main/         — Electron main process (IPC, security, file ops)
+  renderer/     — React app (components, store, styles)
+tests/
+  unit/         — Vitest unit tests
+  e2e/          — Playwright Electron E2E tests
+```
+
+Key patterns:
+- **Store** (`store.ts`) — Zustand, single source of truth
+- **IPC boundary** — all file access validated in main process
+- **Theming** — CSS custom properties in `themes.css`, applied via `data-theme` attribute
+- **Print** — `@media print` strips colours, honours typography settings
+
+## Review Process
+
+Significant changes go through Gestalt multi-agent review (Claude, Gemini, Codex) with up to 3 rounds before merging. This is handled by the maintainers — you don't need to run Gestalt yourself.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.


### PR DESCRIPTION
## Summary

Adds contributor documentation so external contributors know how to report bugs, request features, and submit PRs.

## Changes

- **CONTRIBUTING.md** — complete guide covering:
  - How to report bugs (with environment details, repro steps)
  - How to request features
  - Development setup and testing commands
  - PR process: branch, test, submit
  - What we look for: security, performance, accessibility, bundle size
  - Code style conventions
  - Architecture overview
  - Review process (Gestalt multi-agent review explained)
- **`.github/ISSUE_TEMPLATE/bug_report.md`** — structured bug report template
- **`.github/ISSUE_TEMPLATE/feature_request.md`** — feature request template
- **`.github/pull_request_template.md`** — PR template with test plan checklist

## Test plan

- [x] No code changes — documentation only
- [x] Templates render correctly on GitHub (verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)